### PR TITLE
feat: help scss functions

### DIFF
--- a/src/assets/scss/helpers/_font.scss
+++ b/src/assets/scss/helpers/_font.scss
@@ -1,0 +1,30 @@
+// Размер шрифта
+@each $size in $font-sizes {
+
+	@each $breakpoint, $breakpoint-value in $grid-breakpoints {
+		@if $breakpoint == xs {
+			@include media-breakpoint-down(sm) {
+				.fs-#{$breakpoint}-#{strip-unit($size)} {
+					font-size: rem($size) !important;
+				}
+			}
+		} @else {
+			@include media-breakpoint-up($breakpoint) {
+				.fs-#{$breakpoint}-#{strip-unit($size)} {
+					font-size: rem($size) !important;
+				}
+			}
+		}
+	}
+
+	.fs-#{strip-unit($size)} {
+		font-size: rem($size) !important;
+	}
+}
+
+// Толщина шрифта
+@each $v in 100, 200, 300, 400, 500, 600, 700, 800, 900 {
+	.fw-#{$v} {
+		font-weight: $v !important;
+	}
+}

--- a/src/assets/scss/helpers/_functions.scss
+++ b/src/assets/scss/helpers/_functions.scss
@@ -1,0 +1,11 @@
+@use "sass:math";
+
+// Удаление единицы измерения (16px -> 16)
+@function strip-unit($v) {
+	@return math.div($v, $v * 0 + 1);
+}
+
+// px -> rem
+@function rem($v) {
+	@return #{strip-unit(math.div($v, $base-size-px))} + rem;
+}

--- a/src/assets/scss/index.scss
+++ b/src/assets/scss/index.scss
@@ -2,4 +2,6 @@
 @import "variables";
 @import "helpers/bootstrap";
 @import "helpers/focus-visible";
+@import "helpers/functions";
+@import "helpers/font";
 @import "base";

--- a/src/assets/scss/variables.scss
+++ b/src/assets/scss/variables.scss
@@ -1,6 +1,10 @@
 $font-default: "Roboto";
 $font-family-base: $font-default, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 
+// Helpers
+$base-size-px: 16px; // Базовый размер шрифта в px (helpers/_functions.scss)
+$font-sizes: ( 12px, 16px, 24px ); // Размеры шрифтов (helpers/_font.scss)
+
 // Bootstrap Spacers
 $spacer: 1rem;          // 16px
 $spacers: (


### PR DESCRIPTION
Добавление для scss вспомогательной функции конвертирования px в rem, пример:

```scss
.test {
    font-size: rem(16px);
    // или
    font-size: rem(16);
}
```

Добавление классов для задания размера и толщины шрифта блока:

```html
<div class="fs-md-12 fs-xl-16 fw-100"></div>
```

Массив размеров шрифтов задаётся в переменной `$font-sizes`.